### PR TITLE
Allow loading of non-default-constructible types like abstract base classes

### DIFF
--- a/include/vg/io/message_emitter.hpp
+++ b/include/vg/io/message_emitter.hpp
@@ -36,7 +36,7 @@ using namespace std;
  * - A 64-bit varint with the number of messages plus 1
  * - A 32-bit varint header/tag length
  * - Header/tag data
- * And then for each message item:
+ * And then for each message item (0 or more):
  * - A 32-bit varint message length
  * - Message data
  *

--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -49,7 +49,8 @@ public:
     
     /// Represents a pair of a tag value and some message data.
     /// If there is no valid tag for a group, as given in the Registry, the tag will be "".
-    using TaggedMessage = pair<string, string>;
+    /// If there is a tag but no messages in its group, the data pointer will be null.
+    using TaggedMessage = pair<string, unique_ptr<string>>;
     
     ///////////
     // C++ Iterator Interface
@@ -83,15 +84,15 @@ public:
     static std::pair<MessageIterator, MessageIterator> range(istream& in);
     
     ///////////
-    // has_next()/take() interface
+    // has_current()/take() interface
     ///////////
     
     /// Return true if dereferencing the iterator will produce a valid value, and false otherwise.
-    bool has_next() const;
+    bool has_current() const;
     
     /// Advance the iterator to the next message, or the end if this was the last message.
     /// Basically the same as ++.
-    void get_next();
+    void advance();
     
     /// Take the current item, which must exist, and advance the iterator to the next one.
     TaggedMessage take();

--- a/include/vg/io/vpkg.hpp
+++ b/include/vg/io/vpkg.hpp
@@ -333,6 +333,9 @@ public:
         // Make an emitter to emit tagged messages
         MessageEmitter emitter(out);
         
+        // Mark that we serialized something with this tag, even if there aren't actually any messages.
+        message_emitter.write(tag_and_saver->first);
+        
         // Start the save
         tag_and_saver->second((const void*)&have, [&](const string& message) {
             // For each message that we have to output during the save, output it via the emitter with the selected tag.

--- a/include/vg/io/vpkg.hpp
+++ b/include/vg/io/vpkg.hpp
@@ -491,7 +491,7 @@ private:
      * This version matches default-consttructable types.
      */
     template <typename T>
-    typename std::enable_if<std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
+    static typename std::enable_if<std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
         return make_unique<T>();
     }
     
@@ -502,7 +502,7 @@ private:
      * This version matches non-default-consttructable types.
      */
     template <typename T>
-    typename std::enable_if<!std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
+    static typename std::enable_if<!std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
         return unique_ptr<T>(nullptr);
     }
 };

--- a/include/vg/io/vpkg.hpp
+++ b/include/vg/io/vpkg.hpp
@@ -205,8 +205,8 @@ public:
             // If we get here, nothing with an appropriate tag could be found, and it wasn't a bare loadable file.
             return unique_ptr<Wanted>(nullptr);
         } else {
-            // If the file is empty, default construct.
-            return make_unique<Wanted>();
+            // If the file is empty, default construct if possible. Else return null.
+            return make_default_or_null<Wanted>();
         }
     }
     
@@ -482,6 +482,28 @@ private:
         }
         
         return demangled;
+    }
+    
+    /**
+     * Return a new default-constructed instance of the given type, or a null
+     * pointer if it is not default constructible.
+     *
+     * This version matches default-consttructable types.
+     */
+    template <typename T>
+    typename std::enable_if<std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
+        return make_unique<T>();
+    }
+    
+    /**
+     * Return a new default-constructed instance of the given type, or a null
+     * pointer if it is not default constructible.
+     *
+     * This version matches non-default-consttructable types.
+     */
+    template <typename T>
+    typename std::enable_if<!std::is_default_constructible<T>::value, unique_ptr<T>>::type make_default_or_null() {
+        return unique_ptr<T>(nullptr);
     }
 };
 

--- a/include/vg/io/vpkg.hpp
+++ b/include/vg/io/vpkg.hpp
@@ -334,7 +334,7 @@ public:
         MessageEmitter emitter(out);
         
         // Mark that we serialized something with this tag, even if there aren't actually any messages.
-        message_emitter.write(tag_and_saver->first);
+        emitter.write(tag_and_saver->first);
         
         // Start the save
         tag_and_saver->second((const void*)&have, [&](const string& message) {

--- a/src/message_emitter.cpp
+++ b/src/message_emitter.cpp
@@ -20,7 +20,7 @@ MessageEmitter::MessageEmitter(ostream& out, size_t max_group_size) :
     cerr << "Creating MessageEmitter" << endl;
 #endif
     if (bgzip_out->Tell() == -1) {
-        // Say we are starting at the beginnign of the stream, if we don't know where we are.
+        // Say we are starting at the beginning of the stream, if we don't know where we are.
         bgzip_out->StartFile();
     }
 }

--- a/src/message_emitter.cpp
+++ b/src/message_emitter.cpp
@@ -11,6 +11,8 @@ namespace io {
 
 using namespace std;
 
+#define debug
+
 MessageEmitter::MessageEmitter(ostream& out, size_t max_group_size) :
     group(),
     max_group_size(max_group_size),
@@ -58,6 +60,9 @@ void MessageEmitter::write(const string& tag) {
     if (tag != group_tag) {
         // Adopt the new tag
         group_tag = tag;
+#ifdef debug
+        cerr << "Adopting tag " << group_tag << endl;
+#endif
     }
 }
 
@@ -107,9 +112,17 @@ void MessageEmitter::emit_group() {
 
     ::google::protobuf::io::CodedOutputStream coded_out(bgzip_out.get());
 
+#ifdef debug
+    cerr << "Writing group size of " << (group.size() + 1) << endl;
+#endif
+
     // Prefix the group with the number of objects, plus 1 for the tag header
     coded_out.WriteVarint64(group.size() + 1);
     handle(!coded_out.HadError());
+   
+#ifdef debug
+    cerr << "Writing tag " << group_tag << endl;
+#endif
    
     // Write the tag length and the tag
     coded_out.WriteVarint32(group_tag.size());

--- a/src/message_emitter.cpp
+++ b/src/message_emitter.cpp
@@ -11,8 +11,6 @@ namespace io {
 
 using namespace std;
 
-#define debug
-
 MessageEmitter::MessageEmitter(ostream& out, size_t max_group_size) :
     group(),
     max_group_size(max_group_size),

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -25,7 +25,7 @@ MessageIterator::MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf) :
     item_vo(-1),
     bgzip_in(std::move(bgzf))
 {
-    get_next();
+    advance();
 }
 
 auto MessageIterator::operator*() const -> const TaggedMessage& {
@@ -76,7 +76,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
             group_vo = -1;
             item_vo = -1;
             value.first.clear();
-            value.second.clear();
+            value.second.reset();
             return *this;
         }
         
@@ -95,7 +95,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         handle(coded_in.ReadVarint32(&tagSize));
         
         if (tagSize > MAX_MESSAGE_SIZE) {
-            throw runtime_error("[io::MessageIterator::get_next] tag of " +
+            throw runtime_error("[io::MessageIterator::advance] tag of " +
                                 to_string(tagSize) + " bytes is too long");
         }
         
@@ -149,7 +149,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         if (!is_tag) {
             // If we get here, the registry doesn't think it's a tag.
             // Assume it is actually a message, and make the group's tag ""
-            swap(value.first, value.second);
+            value.second = make_unique<string>(std::move(value.first));
             value.first.clear();
             previous_tag.clear();
             
@@ -169,8 +169,24 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         // Back up its value in case our pair gets moved away.
         previous_tag = value.first;
         
-        // We continue and read the real first message into the message half of our pair.
+        if (is_tag && group_count == 1) {
+            // This group is a tag *only*.
+            // If we hit the end of the loop we'll just skip over it.
+            // We want to emit it as a pair of (tag, null).
+            // So we consider our increment complete here.
+            
+#ifdef debug
+            cerr << "Found message-less tag \"" << value.first << "\"" << endl;
+#endif
+            
+            value.second.reset();
+            return *this;
+        }
+        
+        // We continue through all empty groups.
     }
+    
+    // Now we know we have a message to go with our tag.
     
     // Now we know we're in a group, and we know the tag, if any.
     
@@ -196,15 +212,20 @@ auto MessageIterator::operator++() -> const MessageIterator& {
     handle(coded_in.ReadVarint32(&msgSize));
     
     if (msgSize > MAX_MESSAGE_SIZE) {
-        throw runtime_error("[io::MessageIterator::get_next] message of " +
+        throw runtime_error("[io::MessageIterator::advance] message of " +
                             to_string(msgSize) + " bytes is too long");
     }
     
     
     // We have a message.
-    value.second.clear();
+    // Make an empty string to hold it.
+    if (value.second.get() != nullptr) {
+        value.second->clear();
+    } else {
+        value.second = make_unique<string>();
+    }
     if (msgSize) {
-        handle(coded_in.ReadString(&value.second, msgSize));
+        handle(coded_in.ReadString(value.second.get(), msgSize));
     }
     
     // Fill in the tag from the previous to make sure our value pair actually has it.
@@ -224,26 +245,26 @@ auto MessageIterator::operator++() -> const MessageIterator& {
 
 auto MessageIterator::operator==(const MessageIterator& other) const -> bool {
     // Just ask if we both agree on whether we hit the end.
-    return has_next() == other.has_next();
+    return has_current() == other.has_current();
 }
     
 auto MessageIterator::operator!=(const MessageIterator& other) const -> bool {
     // Just ask if we disagree on whether we hit the end.
-    return has_next() != other.has_next();
+    return has_current() != other.has_current();
 }
 
-auto MessageIterator::has_next() const -> bool {
+auto MessageIterator::has_current() const -> bool {
     return item_vo != -1;
 }
 
-auto MessageIterator::get_next() -> void {
+auto MessageIterator::advance() -> void {
     // Run increment but don't return anything.
     ++(*this);
 }
 
 auto MessageIterator::take() -> TaggedMessage {
     auto temp = std::move(value);
-    get_next();
+    advance();
     // Return by value, which gets moved.
     return temp;
 }
@@ -301,7 +322,7 @@ auto MessageIterator::seek_group(int64_t virtual_offset) -> bool {
 #endif
     
     // Read it (or detect EOF)
-    get_next();
+    advance();
     
     // It worked!
     return true;


### PR DESCRIPTION
This PR lets libvgio work when you do `vg::io::VPKG::load_one<HandleGraph>(stream)`. It detects that a HandleGraph is not default constructible, so if nothing loadable as that type is found, the load will fail at runtime.

Right now, the load fails at compile time, because we can't call the default constructor of HandleGraph in the empty file case.

