### PR TITLE
Handle empty final batches

### DIFF
--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -257,7 +257,8 @@ void for_each_parallel_impl(std::istream& in,
 #ifdef debug
             cerr << "Run final batch of size " << batch->size() << " in current thread" << endl;
 #endif
-            {
+            if (!batch->empty()) {
+                // We require the batch to not be empty (so we can subtract from the size).
                 T obj1, obj2;
                 int i = 0;
                 for (; i < batch->size()-1; i+=2) {
@@ -269,7 +270,7 @@ void for_each_parallel_impl(std::istream& in,
                     handle(obj1.ParseFromString(batch->at(i)));
                     lambda1(obj1);
                 }
-            } // scope obj1 & obj2
+            }
             delete batch;
         }
     }

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -64,7 +64,8 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         // Make a CodedInputStream to read the group length
         ::google::protobuf::io::CodedInputStream coded_in(bgzip_in.get());
         // Alot space for group's length, tag's length, and tag (generously)
-        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2, MAX_MESSAGE_SIZE * 10);
+        // Look out for overflow; these arguments are int (32 bit)
+        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2, numeric_limits<int>::max());
         
         // Try and read the group's length
         if (!coded_in.ReadVarint64((::google::protobuf::uint64*) &group_count)) {


### PR DESCRIPTION
With tag-only items being visible in the MessageIterator, we can now get into a situation where we allocate a batch but never put anything in it. The code to handle the final batch assumes it is nonempty.

I've wrapped it in an if check, so we only actually loop over it if any items are present.

Also, I fixed an int overflow warning, by just passing the biggest int.