### PR TITLE
Decompress vpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,17 @@ add_dependencies(vgio_static link_target)
 add_library(VGio::vgio ALIAS vgio)
 
 # Set target properties
+
+# If we pass exactly ${HTSlib_INCLUDEDIR} or ${Protobuf_INCLUDEDIR} they manage
+# to get filtered out somehow and they aren't passed as -I optiosn to the
+# compiler. So we throw a /. on the end.
 target_include_directories(vgio
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # Capture the Protobuf generated header that lands here.
+        ${HTSlib_INCLUDEDIR}/.
+        ${Protobuf_INCLUDEDIR}/.
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
@@ -75,6 +81,8 @@ target_include_directories(vgio_static
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # Capture the Protobuf generated header that lands here.
+        ${HTSlib_INCLUDEDIR}/.
+        ${Protobuf_INCLUDEDIR}/.
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )

--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -45,9 +45,13 @@ public:
     /// *uncompressed* type-tagged message data, and, if so, what the tag is.
     /// Returns the tag if it could be sniffed, or the empty string if the tag
     /// could not be read, if the tag actually is an (illegal) empty string, or
-    /// if the tag is not valid according to the Registry. Fails with an
-    /// exception if the sniffed data cannot be ungotten.
+    /// if the tag is not valid according to the Registry.
+    ///
     /// Ungets the stream up to where it was before the sniffing read.
+    ///
+    /// Fails with an exception if the sniffed data cannot be ungotten, so not
+    /// safe to run on streams that aren't seekable and don't have buffering to
+    /// support this.
     static string sniff_tag(istream& stream); 
 
     /// Constructor to wrap a stream.

--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -40,6 +40,15 @@ public:
 
     /// We refuse to serialize individual messages longer than this size.
     const static size_t MAX_MESSAGE_SIZE = 1000000000;
+    
+    /// Sniffing function to identify if data in a C++ stream appears to be
+    /// *uncompressed* type-tagged message data, and, if so, what the tag is.
+    /// Returns the tag if it could be sniffed, or the empty string if the tag
+    /// could not be read, if the tag actually is an (illegal) empty string, or
+    /// if the tag is not valid according to the Registry. Fails with an
+    /// exception if the sniffed data cannot be ungotten.
+    /// Ungets the stream up to where it was before the sniffing read.
+    static string sniff_tag(istream& stream); 
 
     /// Constructor to wrap a stream.
     MessageIterator(istream& in);

--- a/include/vg/io/protobuf_emitter.hpp
+++ b/include/vg/io/protobuf_emitter.hpp
@@ -48,8 +48,11 @@ using namespace std;
 template <typename T>
 class ProtobufEmitter {
 public:
-    /// Constructor
-    ProtobufEmitter(std::ostream& out, size_t max_group_size = 1000);
+    /// Constructor. Writes type-tagged Protobuf data to the given output
+    /// stream. If compress is true, data will be BGZF-compressed. The maximum
+    /// number of Protobuf messages in a tagged group is controlled by
+    /// max_group_size.
+    ProtobufEmitter(std::ostream& out, bool compress = false, size_t max_group_size = 1000);
     
     /// Destructor that finishes the file
     ~ProtobufEmitter();
@@ -136,7 +139,7 @@ std::function<void(const Item&)> emit_to(ostream& out);
 /////////
 
 template<typename T>
-ProtobufEmitter<T>::ProtobufEmitter(std::ostream& out, size_t max_group_size) : message_emitter(out, max_group_size),
+ProtobufEmitter<T>::ProtobufEmitter(std::ostream& out, bool compress, size_t max_group_size) : message_emitter(out, compress, max_group_size),
     tag(Registry::get_protobuf_tag<T>()) {
     // Make sure to write at least the tag to the file, to represent 0
     // instances of our type. When trying to load a list of our type from a

--- a/include/vg/io/protobuf_emitter.hpp
+++ b/include/vg/io/protobuf_emitter.hpp
@@ -37,6 +37,8 @@ using namespace std;
  * Note that the callbacks may be called by the ProtobufEmitter's destructor,
  * so anything they reference needs to outlive the ProtobufEmitter.
  *
+ * Writes compressed VPKG data by default.
+ *
  * May be more efficient than repeated write/write_buffered calls because a
  * single BGZF stream can be used.
  *
@@ -52,7 +54,7 @@ public:
     /// stream. If compress is true, data will be BGZF-compressed. The maximum
     /// number of Protobuf messages in a tagged group is controlled by
     /// max_group_size.
-    ProtobufEmitter(std::ostream& out, bool compress = false, size_t max_group_size = 1000);
+    ProtobufEmitter(std::ostream& out, bool compress = true, size_t max_group_size = 1000);
     
     /// Destructor that finishes the file
     ~ProtobufEmitter();

--- a/include/vg/io/protobuf_iterator.hpp
+++ b/include/vg/io/protobuf_iterator.hpp
@@ -27,7 +27,6 @@ namespace io {
 
 using namespace std;
 
-
 /**
  * Refactored io::for_each function that follows the unidirectional iterator interface.
  * Also supports seeking and telling at the group level in bgzip files.

--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -141,6 +141,8 @@ public:
     
     /**
      * To help with telling messages from tags, we enforce a max tag length.
+     * If we ever allow tags of 139 bytes or longer, we risk having
+     * uncompressed files starting with the gzip magic number.
      */
     static const size_t MAX_TAG_LENGTH = 25;
     

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -26,7 +26,7 @@ using namespace std;
 /// Write the EOF marker to the given stream, so that readers won't complain that it might be truncated when they read it in.
 /// Internal EOF markers MAY exist, but a file SHOULD have exactly one EOF marker at its end.
 /// Needs to know if the output stream is compressed or not. Note that uncompressed streams don't actually have nonempty EOF markers.
-void finish(std::ostream& out, bool compressed);
+void finish(std::ostream& out, bool compressed = true);
 
 /// Write objects. count should be equal to the number of objects to write.
 /// count is written before the objects, but if it is 0, it is not written. To
@@ -34,7 +34,7 @@ void finish(std::ostream& out, bool compressed);
 /// not all objects are written, return false, otherwise true.
 /// Needs to know whether to BGZF-compress the output or not.
 template <typename T>
-bool write(std::ostream& out, size_t count, const std::function<T&(size_t)>& lambda, bool compressed = false) {
+bool write(std::ostream& out, size_t count, const std::function<T&(size_t)>& lambda, bool compressed = true) {
 
     // Wrap stream in an emitter
     ProtobufEmitter<T> emitter(out, compressed);
@@ -54,7 +54,7 @@ bool write(std::ostream& out, size_t count, const std::function<T&(size_t)>& lam
 /// This implementation takes a function that returns actual objects and not references.
 /// Needs to know whether to BGZF-compress the output or not.
 template <typename T>
-bool write(std::ostream& out, size_t count, const std::function<T(size_t)>& lambda, bool compressed = false) {
+bool write(std::ostream& out, size_t count, const std::function<T(size_t)>& lambda, bool compressed = true) {
 
     static_assert(!std::is_reference<T>::value, "This write() implementation doesn't operate on references");
 
@@ -77,7 +77,7 @@ bool write(std::ostream& out, size_t count, const std::function<T(size_t)>& lamb
 /// Returns true unless an error occurs.
 /// Needs to know whether to BGZF-compress the output or not.
 template <typename T>
-bool write_buffered(std::ostream& out, std::vector<T>& buffer, size_t buffer_limit, bool compressed = false) {
+bool write_buffered(std::ostream& out, std::vector<T>& buffer, size_t buffer_limit, bool compressed = true) {
     bool wrote = false;
     if (buffer.size() >= buffer_limit) {
         std::function<T(size_t)> lambda = [&buffer](size_t n) { return buffer.at(n); };

--- a/src/message_emitter.cpp
+++ b/src/message_emitter.cpp
@@ -11,15 +11,25 @@ namespace io {
 
 using namespace std;
 
-MessageEmitter::MessageEmitter(ostream& out, size_t max_group_size) :
+MessageEmitter::MessageEmitter(ostream& out, bool compress, size_t max_group_size) :
     group(),
     max_group_size(max_group_size),
-    bgzip_out(new BlockedGzipOutputStream(out))
+    bgzip_out(compress ? new BlockedGzipOutputStream(out) : nullptr),
+    uncompressed_out(compress ? nullptr : new google::protobuf::io::OstreamOutputStream(&out)),
+    uncompressed_out_ostream(compress ? nullptr : &out),
+    uncompressed_out_written(0)
 {
 #ifdef debug
     cerr << "Creating MessageEmitter" << endl;
 #endif
-    if (bgzip_out->Tell() == -1) {
+
+    // GZIP magic number is: 0x1F 0x8B
+    // Protobuf varint encoding is: break into groups of 7 bits, send them out least-significant first, set high bit on all but the last.
+    // Each type-tagged message file starts with the number of items (including tag) in its group.
+    // GZIP magic number decoded like this looks like a group of 31 messages with an initial message (tag) with >=139 bytes.
+    // So as long as we enforce a tag length of < that we won't have a problem.
+    
+    if (bgzip_out.get() != nullptr && bgzip_out->Tell() == -1) {
         // Say we are starting at the beginning of the stream, if we don't know where we are.
         bgzip_out->StartFile();
     }
@@ -29,14 +39,17 @@ MessageEmitter::~MessageEmitter() {
 #ifdef debug
     cerr << "Destroying MessageEmitter" << endl;
 #endif
-    if (bgzip_out.get() != nullptr) {
+    
+    if (bgzip_out.get() != nullptr || uncompressed_out.get() != nullptr) {
 #ifdef debug
         cerr << "MessageEmitter emitting final group" << endl;
 #endif
     
         // Before we are destroyed, write stuff out.
         emit_group();
-        
+    }
+
+    if (bgzip_out.get() != nullptr) {
 #ifdef debug
         cerr << "MessageEmitter ending file" << endl;
 #endif
@@ -97,7 +110,7 @@ void MessageEmitter::emit_group() {
     
     
     // We can't write a non-empty buffer if our stream is gone/moved away
-    assert(bgzip_out.get() != nullptr);
+    assert(bgzip_out.get() != nullptr || uncompressed_out.get() != nullptr);
     
     auto handle = [](bool ok) {
         if (!ok) {
@@ -106,9 +119,11 @@ void MessageEmitter::emit_group() {
     };
 
     // Work out where the group we emit will start
-    int64_t virtual_offset = bgzip_out->Tell();
+    int64_t virtual_offset = (bgzip_out.get() != nullptr) ? bgzip_out->Tell() : (uncompressed_out_written + uncompressed_out->ByteCount());
 
-    ::google::protobuf::io::CodedOutputStream coded_out(bgzip_out.get());
+    ::google::protobuf::io::CodedOutputStream coded_out((bgzip_out.get() != nullptr) ? 
+        (::google::protobuf::io::ZeroCopyOutputStream*) bgzip_out.get() :
+        (::google::protobuf::io::ZeroCopyOutputStream*) uncompressed_out.get());
 
 #ifdef debug
     cerr << "Writing group size of " << (group.size() + 1) << endl;
@@ -144,7 +159,7 @@ void MessageEmitter::emit_group() {
     
     // Work out where we ended
     coded_out.Trim();
-    int64_t next_virtual_offset = bgzip_out->Tell();
+    int64_t next_virtual_offset = (bgzip_out.get() != nullptr) ? bgzip_out->Tell() : (uncompressed_out_written + uncompressed_out->ByteCount());
     
     for (auto& handler : group_handlers) {
         // Report the group to each group handler that is listening.
@@ -163,8 +178,18 @@ void MessageEmitter::flush() {
     // Make sure to emit our group, if any.
     emit_group();
     
-    assert(bgzip_out != nullptr);
-    bgzip_out->Flush(); 
+    assert(bgzip_out.get() != nullptr || uncompressed_out.get() != nullptr);
+    if (bgzip_out.get() != nullptr) {
+        bgzip_out->Flush();
+    }
+    if (uncompressed_out.get() != nullptr) {
+        // Remember how much was written from this stream
+        uncompressed_out_written += uncompressed_out->ByteCount();
+        // Destroy and recreate it to empty its buffer.
+        uncompressed_out.release();
+        uncompressed_out.reset(new google::protobuf::io::OstreamOutputStream(uncompressed_out_ostream));
+        
+    }
 }
 
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -7,10 +7,12 @@ namespace io {
 
 using namespace std;
 
-void finish(std::ostream& out) {
-    // Put an EOF on the stream by making a writer, marking it as EOF, and letting it clean up.
-    BlockedGzipOutputStream bgzip_out(out);
-    bgzip_out.EndFile();
+void finish(std::ostream& out, bool compressed) {
+    if (compressed) {
+        // Put an EOF on the stream by making a writer, marking it as EOF, and letting it clean up.
+        BlockedGzipOutputStream bgzip_out(out);
+        bgzip_out.EndFile();
+    }
 }
 
 }

--- a/src/stream_multiplexer.cpp
+++ b/src/stream_multiplexer.cpp
@@ -12,7 +12,6 @@ namespace io {
 
 using namespace std;
 
-
 /// Don't deal with anything smaller than a few BGZF blocks.
 const size_t StreamMultiplexer::MIN_QUEUE_ITEM_BYTES = 10 * 64 * 1024;
 
@@ -71,7 +70,7 @@ void StreamMultiplexer::register_breakpoint(size_t thread_number) {
         // We have enough data to justify a block.
         
 #ifdef debug
-    cerr << "StreamMultiplexer registered breakpoint for " << item_bytes << " bytes in thread " << thread_number << endl;
+        cerr << "StreamMultiplexer registered breakpoint for " << item_bytes << " bytes in thread " << thread_number << endl;
 #endif
         
         // Lock our queue
@@ -123,6 +122,10 @@ bool StreamMultiplexer::want_breakpoint(size_t thread_number) {
     
     // See how much data it has
     size_t item_bytes = our_stream.tellp();
+    
+#ifdef debug
+    cerr << "Checking for breakpoint at " << item_bytes << "/" << MIN_QUEUE_ITEM_BYTES << " bytes" << endl;
+#endif
     
     // Ask them to give us a break if they have enough bytes for us to ship out.
     return (item_bytes >= MIN_QUEUE_ITEM_BYTES);
@@ -223,6 +226,11 @@ void StreamMultiplexer::discard_bytes(size_t thread_number, size_t count) {
 }
 
 void StreamMultiplexer::writer_thread_function() {
+
+#ifdef debug
+    cerr << "StreamMultiplexer writer starting" << endl;
+#endif
+
 #ifdef debug
     // Track the max bytes obeserved in any queue
     size_t high_water_bytes = 0;
@@ -325,7 +333,7 @@ void StreamMultiplexer::writer_thread_function() {
     }
     
 #ifdef debug
-    cerr << "StreamMultiplexer high water mark: " << high_water_length << " items, " << high_water_bytes << " bytes" << endl;
+    cerr << "StreamMultiplexer high water mark: " << high_water_bytes << " bytes across " << thread_queues.size() << " threads" << endl;
 #endif
 }
 


### PR DESCRIPTION
This allows for VPKG to be compressed or uncompressed, and makes it uncompressed by default.

It required an htslib with https://github.com/samtools/htslib/pull/901 for random access in these uncompressed files to work correctly.