### PR TITLE
Use C++14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(libvgio VERSION 0.0.0 LANGUAGES CXX)
 # Optimize by default, but also include debug info
 set(CMAKE_CXX_FLAGS "-O3 -g")
 
+# Use C++14, so that Protobuf headers that use lambdas will work.
+set(CMAKE_CXX_STANDARD 14)
+
 # Declare dependencies and explain how to find them
 find_package(PkgConfig REQUIRED)
 


### PR DESCRIPTION
I had a build of vg fail because Protobuf headers used by libvgio had lambda functions in them and -std=c++14 wasn't making it into libvgio's build. Since some Protobuf releases need a modern C++, I am making libvgio need a modern C++.