### PR TITLE
Sniff Proto Streams and Allow Multiple Loaders

### DIFF
--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -52,7 +52,16 @@ public:
     /// Fails with an exception if the sniffed data cannot be ungotten, so not
     /// safe to run on streams that aren't seekable and don't have buffering to
     /// support this.
-    static string sniff_tag(istream& stream); 
+    static string sniff_tag(istream& stream);
+    
+    /// Sniffing function to identify if data in a ZeroCopyInputStream appears
+    /// to be *uncompressed* type-tagged message data, and, if so, what the tag
+    /// is. Returns the tag if it could be sniffed, or the empty string if the
+    /// tag could not be read, if the tag actually is an (illegal) empty
+    /// string, or if the tag is not valid according to the Registry.
+    ///
+    /// BackUps the stream up to where it was before the sniffing read.
+    static string sniff_tag(::google::protobuf::io::ZeroCopyInputStream& stream);
 
     /// Constructor to wrap a stream.
     MessageIterator(istream& in);


### PR DESCRIPTION
This allows tags to be sniffed from Protobuf-style streams like the BlockedGzipInputStream.

It also allows loaders to be registered separately from savers, and to be registered for multiple tags, in the Registry. This is useful for adding loaders that convert formats, where you don't necessarily want a corresponding saver.