### PR TITLE
Make max emitter message size static to silence clang warnings

### DIFF
--- a/include/vg/io/message_emitter.hpp
+++ b/include/vg/io/message_emitter.hpp
@@ -59,7 +59,7 @@ class MessageEmitter {
 public:
 
     /// We refuse to serialize individual messages longer than this size.
-    const size_t MAX_MESSAGE_SIZE = 1000000000;
+    const static size_t MAX_MESSAGE_SIZE;
 
     /// Constructor. Write output to the given stream. If compress is true,
     /// compress it as BGZF. Limit the maximum number of messages in a group to

--- a/src/message_emitter.cpp
+++ b/src/message_emitter.cpp
@@ -11,6 +11,9 @@ namespace io {
 
 using namespace std;
 
+// Give the static member variable a .o home
+const size_t MessageEmitter::MAX_MESSAGE_SIZE = 1000000000;
+
 MessageEmitter::MessageEmitter(ostream& out, bool compress, size_t max_group_size) :
     group(),
     max_group_size(max_group_size),


### PR DESCRIPTION
This is not particularly serious, but I get a ton of annoying clang warnings when compiling VG (one for every source file that has a transitive message_emitter.hpp include) about how the move constructor is implicitly deleted because `MAX_MESSAGE_SIZE` is const. I'm assuming that there won't be any issue making it const static like the equivalent variable for the `MessageIterator`. 