### PR TITLE
Buffer standard input to allow putback

### DIFF
--- a/src/vpkg.cpp
+++ b/src/vpkg.cpp
@@ -42,7 +42,7 @@ bool VPKG::sniff_magic(istream& stream, const string& magic) {
     char buffer[to_sniff];
     // Have a cursor in the buffer
     size_t buffer_used = 0;
-    
+
     while (stream.peek() != EOF && buffer_used < to_sniff) {
         // Until we fill the buffer or would hit EOF, fill the buffer
         buffer[buffer_used] = (char) stream.get();


### PR DESCRIPTION
We can't sniff for magic numbers on standard input, because the standard library provides no way to unget the characters we sniff. This prevents libbdsg graphs being streamed from tool to tool without VPKG framing. But the VPKG framing prevents libbdsg from reading them, and especially prevents potential mmap-based acceleration for on-disk reads.

This enables libvgio to read non-VPKG-framed data from standard input, by adding a buffering stream wrapper when reading from standard input.

Problems with reading from named pipes probably still exist; we ought to consider detecting and wrapping them too.

We might want to experiment to find a fast buffer size on all platforms.