### PR TITLE
Generalize VPKG loader for GFA support

### DIFF
--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -438,10 +438,9 @@ void Registry::register_bare_loader_saver_with_magics(const string& tag, const v
     
     for (auto& magic : magics) {
         // Register the bare stream loader for each magic
-        function<bool(istream&)> check_header = [&magic](istream& in_stream) {
-            return sniff_magic(in_stream, magic);  
-        };
-        register_bare_loader<Handled, Bases...>(loader, check_header);
+        register_bare_loader<Handled, Bases...>(loader, [magic](istream& in_stream) {
+                return sniff_magic(in_stream, magic);  
+            });
     }
 }
 

--- a/include/vg/io/vpkg.hpp
+++ b/include/vg/io/vpkg.hpp
@@ -205,12 +205,13 @@ public:
                         // Just linear scan through all the loaders
                     
                         auto check_header_fn = loader_and_prefix.second;
-                        if (check_header_fn != nullptr && check_header_fn(from)) {
+                        // Note: previous logic returned true for empty magic numbers,
+                        // so accepting nullptr here does the same
+                        if (check_header_fn == nullptr || check_header_fn(from)) {
                             // Use the first prefix-match we find.
                             // Up to the user to avoid prefix overlap.
                             return unique_ptr<Wanted>((Wanted*)(loader_and_prefix.first)(from, filename));
                         }
-                        // todo: do we need to do something if check_header_fn is null? 
                     }
                     
                     // If there's no matching bare loader, just keep going

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -324,6 +324,65 @@ auto wrap_bare_saver(function<void(const void*, ostream&)> ostream_saver) -> sav
     };
 }
 
+bool Registry::sniff_magic(istream& stream, const string& magic) {
+
+    if (!stream) {
+        // Can't read anything, so obviously it can't match.
+        return false;
+    }
+    
+    // Work out how many characters to try and sniff.
+    // We require that our C++ STL can do this much ungetting, even though the
+    // standard guarantees absolutely no ungetting.
+    size_t to_sniff = magic.size();
+    
+    // Allocate a buffer
+    char buffer[to_sniff];
+    // Have a cursor in the buffer
+    size_t buffer_used = 0;
+
+    while (stream.peek() != EOF && buffer_used < to_sniff) {
+        // Until we fill the buffer or would hit EOF, fill the buffer
+        buffer[buffer_used] = (char) stream.get();
+        buffer_used++;
+    }
+
+    for (size_t i = 0; i < buffer_used; i++) {
+        // Now unget all the characters again.
+        // C++11 says we can unget from EOF.
+        stream.unget();
+        if (!stream) {
+            // We did something the stream disliked.
+            throw runtime_error("Ungetting failed after " + to_string(i) + " characters");
+        }
+    }
+    
+    // Now all the characters are back in the stream.
+    
+    if (!stream) {
+        // We reached EOF when sniffing the magic. We managed to unget
+        // everything (maybe the file is empty). But we need to clear errors on
+        // the stream so it is like it was when we started.
+        stream.clear();
+    }
+
+    if (buffer_used < magic.size()) {
+        // We ran out of data
+        return false;
+    }
+    
+    for (size_t i = 0; i < buffer_used; i++) {
+        // Check each character
+        if (buffer[i] != magic[i]) {
+            // And on a mismatch, fail
+            return false;
+        }
+    }
+    
+    // If we get here, there were no mismatches
+    return true;
+}
+
 }
 
 }

--- a/src/vpkg.cpp
+++ b/src/vpkg.cpp
@@ -26,65 +26,6 @@ void VPKG::with_save_stream(ostream& to, const string& tag, const function<void(
     });
 }
 
-bool VPKG::sniff_magic(istream& stream, const string& magic) {
-
-    if (!stream) {
-        // Can't read anything, so obviously it can't match.
-        return false;
-    }
-    
-    // Work out how many characters to try and sniff.
-    // We require that our C++ STL can do this much ungetting, even though the
-    // standard guarantees absolutely no ungetting.
-    size_t to_sniff = magic.size();
-    
-    // Allocate a buffer
-    char buffer[to_sniff];
-    // Have a cursor in the buffer
-    size_t buffer_used = 0;
-
-    while (stream.peek() != EOF && buffer_used < to_sniff) {
-        // Until we fill the buffer or would hit EOF, fill the buffer
-        buffer[buffer_used] = (char) stream.get();
-        buffer_used++;
-    }
-
-    for (size_t i = 0; i < buffer_used; i++) {
-        // Now unget all the characters again.
-        // C++11 says we can unget from EOF.
-        stream.unget();
-        if (!stream) {
-            // We did something the stream disliked.
-            throw runtime_error("Ungetting failed after " + to_string(i) + " characters");
-        }
-    }
-    
-    // Now all the characters are back in the stream.
-    
-    if (!stream) {
-        // We reached EOF when sniffing the magic. We managed to unget
-        // everything (maybe the file is empty). But we need to clear errors on
-        // the stream so it is like it was when we started.
-        stream.clear();
-    }
-
-    if (buffer_used < magic.size()) {
-        // We ran out of data
-        return false;
-    }
-    
-    for (size_t i = 0; i < buffer_used; i++) {
-        // Check each character
-        if (buffer[i] != magic[i]) {
-            // And on a mismatch, fail
-            return false;
-        }
-    }
-    
-    // If we get here, there were no mismatches
-    return true;
-}
-
 }
 
 }


### PR DESCRIPTION
There are 2 hacks here
1) Instead of taking a `string` for magic number prefix checks when setting a loader, take a `function<bool(istream&)>` instead. The function can be used to check a magic number (as previously) or try to do something slightly more complicated like checking against a set of candidate GFA start characters.
2) When calling `load_one()` on a filename (as opposed to a stream), keep that filename remembered alongside the resulting stream.  So now the loader callback that would normally just see an istream, gets the filename too (unless `load_one()` was called directly on the stream).  This allows the GFA loader to be more efficient by going through the file whenever possible, avoiding the potential need to fall back on a temporary file if something's unordered.   