### PR TITLE
Support cg cigars in GAF

### DIFF
--- a/src/alignment_io.cpp
+++ b/src/alignment_io.cpp
@@ -445,7 +445,6 @@ void gaf_to_alignment(function<size_t(nid_t)> node_to_length, function<string(ni
                     from_cg = true;
                 }
 
-                // note: without bases, we don't bother distinguishing between the 3 different cg tags below.
                 if (cigar_cat == ':' || cigar_cat == 'M' || cigar_cat == '=' || cigar_cat == 'X') {
                     int64_t match_len = (int64_t)cigar_len;
                     while (match_len > 0) {
@@ -453,6 +452,10 @@ void gaf_to_alignment(function<size_t(nid_t)> node_to_length, function<string(ni
                         Edit* edit = aln.mutable_path()->mutable_mapping(cur_mapping)->add_edit();
                         edit->set_from_length(current_match);
                         edit->set_to_length(current_match);
+                        if (cigar_cat == 'X') {
+                            // add a phony snp
+                            edit->set_sequence(string(current_match, 'N'));
+                        }
                         if (node_to_sequence) {
                             sequence += node_to_sequence(cur_position.node_id(), cur_position.is_reverse()).substr(cur_offset, current_match);
                         }


### PR DESCRIPTION
Presently, only `cs` cigars are read, as they contain the insertion and subsitution sequences we've come to expect from GAM.  This updates the GAF parser to fall back on `cg` cigars if `cs` cigars aren't found.  There's less information (SNPs get glossed over, insertions sequences are filled with Ns), but the results can still be useful, ie for `vg pack`. 