### PR TITLE
Fix interval parsing bug in gafkluge

### DIFF
--- a/include/vg/io/gafkluge.hpp
+++ b/include/vg/io/gafkluge.hpp
@@ -135,7 +135,7 @@ inline void parse_gaf_record(const std::string& gaf_line, GafRecord& gaf_record)
                 step.is_interval = false;
             } else {
                 // colon, we interpret the step as a stable path interval
-                step.name = step_token.substr(1, colon);
+                step.name = step_token.substr(1, colon - 1);
                 step.is_stable = true;
                 step.is_interval = true;
                 size_t dash = step_token.find_first_of('-', colon);
@@ -227,7 +227,7 @@ inline std::ostream& operator<<(std::ostream& os, const gafkluge::GafStep& gaf_s
     }
     os << gaf_step.name;
     if (gaf_step.is_interval) {
-        os << gaf_step.start << "-" << gaf_step.end;
+        os << ":" <<  gaf_step.start << "-" << gaf_step.end;
     }
     return os;
 }


### PR DESCRIPTION
This type of record isn't (yet) used by vg, so I guess this is why it never came up, but just found a bug when using gafkluge on minigraph output where path steps of the form `chr1:0-100` would end up with contig name `chr1:` instead of `chr1` 