### PR TITLE
Fix bad GAF parsing bug

### DIFF
--- a/include/vg/io/gafkluge.hpp
+++ b/include/vg/io/gafkluge.hpp
@@ -125,7 +125,7 @@ inline void parse_gaf_record(const std::string& gaf_line, GafRecord& gaf_record)
             GafStep step;
             pos = buffer.find_first_of("><", pos);
             next = buffer.find_first_of("><", pos + 1);
-            std::string step_token = buffer.substr(pos, next);
+            std::string step_token = buffer.substr(pos, next != std::string::npos ? next - pos + 1 : std::string::npos);
             size_t colon = step_token.find_first_of(':');
             step.is_reverse = step_token[0] == '<';
             if (colon == std::string::npos) {
@@ -142,7 +142,7 @@ inline void parse_gaf_record(const std::string& gaf_line, GafRecord& gaf_record)
                 if (dash == std::string::npos) {
                     throw std::runtime_error("Error parsing GAF range of " + step_token);
                 }
-                step.start = std::stol(step_token.substr(colon + 1, dash));
+                step.start = std::stol(step_token.substr(colon + 1, dash - colon));
                 step.end = std::stol(step_token.substr(dash + 1));
             }
             gaf_record.path.push_back(step);


### PR DESCRIPTION
(Stacks on #40)

A couple of bad habits of mine combined to hide a serious bug in GAF parsing:
1. passing end positions instead of lengths to the second parameter of `string::substr()`
2. forgetting that `stol()` silently ignores non-numeric trailing characters

The result is that a path  like`1>2>3>4>5` was getting parsed into steps with names like
`1`
`2>3`
`3>4>5` etc. where the strings get bigger as you go.  

Since `stol("3>4>5") = 3`, the results ended up looking fine for all vg-based testing.  It was only today seeing the quadratic memory needed to parse a chr8 path go past 300G did I realize something was wrong...