### PR TITLE
Make CMake minimum version reflect reality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.13)
 project(libvgio VERSION 0.0.0 LANGUAGES CXX)
 
 # Optimize by default, but also include debug info


### PR DESCRIPTION
In #45 we bumped the version of CMake we need to work properly, but didn't actually tell CMake about it.

This also drops support for Ubuntu 18.04 as a build platform, unless you get a newer CMake from somewhere else, like https://apt.kitware.com/