### PR TITLE
Use single-argument version of SetTotalBytesLimit

### DIFF
--- a/include/vg/io/protobuf_iterator.hpp
+++ b/include/vg/io/protobuf_iterator.hpp
@@ -271,7 +271,7 @@ auto ProtobufIterator<T>::parse_from_string(T& dest, const string& data) -> bool
     google::protobuf::io::CodedInputStream coded_stream(&array_stream);
     
     // Up the total byte limit
-    coded_stream.SetTotalBytesLimit(MessageIterator::MAX_MESSAGE_SIZE * 2, MessageIterator::MAX_MESSAGE_SIZE * 2);
+    coded_stream.SetTotalBytesLimit(MessageIterator::MAX_MESSAGE_SIZE * 2);
     
     // Now actually parse the message
     return dest.ParseFromCodedStream(&coded_stream);

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -189,7 +189,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         // Make a CodedInputStream to read the group length
         ::google::protobuf::io::CodedInputStream coded_in(bgzip_in.get());
         // Alot space for group's length, tag's length, and tag (generously)
-        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2, MAX_MESSAGE_SIZE * 2);
+        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2);
         
         // Try and read the group's length
         if (!coded_in.ReadVarint64((::google::protobuf::uint64*) &group_count)) {
@@ -325,7 +325,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
     // We need a fresh CodedInputStream every time, because of the total byte limit
     ::google::protobuf::io::CodedInputStream coded_in(bgzip_in.get());
     // Alot space for size and item (generously)
-    coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2, MAX_MESSAGE_SIZE * 2);
+    coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2);
     
     // A message starts here
     if (virtual_offset == -1) {


### PR DESCRIPTION
VG Mac tests started having errors like:

```
/Users/runner/work/vg/vg/deps/libvgio/include/vg/io/protobuf_iterator.hpp:274:76: error: too many arguments to function call, expected single argument 'total_bytes_limit', have 2 arguments
    coded_stream.SetTotalBytesLimit(MessageIterator::MAX_MESSAGE_SIZE * 2, MessageIterator::MAX_MESSAGE_SIZE * 2);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/google/protobuf/io/coded_stream.h:406:3: note: 'SetTotalBytesLimit' declared here
  void SetTotalBytesLimit(int total_bytes_limit);
```

The two-argument version of `SetTotalBytesLimit` was apparently deprecated and eventually removed. This should hopefully fix the issue.