### PR TITLE
Support both 1- and 2-parameter versions of setTotalBytesLimit()

### DIFF
--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -18,6 +18,14 @@
 
 #include "blocked_gzip_input_stream.hpp"
 
+
+// protobuf scrapped the two-parameter version of this in 3.6.0
+// https://github.com/protocolbuffers/protobuf/blob/v3.6.0/src/google/protobuf/io/coded_stream.h#L387-L391
+// so we hack in support ourselves
+#if (GOOGLE_PROTOBUF_VERSION < 3006000)
+#define SetTotalBytesLimit(N) SetTotalBytesLimit(N, N)
+#endif
+
 namespace vg {
 
 namespace io {


### PR DESCRIPTION
The switch happened in the change between [3.5](https://github.com/protocolbuffers/protobuf/blob/v3.5.0/src/google/protobuf/io/coded_stream.h#L402) and [3.6](https://github.com/protocolbuffers/protobuf/blob/v3.6.0/src/google/protobuf/io/coded_stream.h#L385).  But since then, it's been consistently 1-parameter ex: [3.17.3](https://github.com/protocolbuffers/protobuf/blob/v3.17.3/src/google/protobuf/io/coded_stream.h#L400), [3.18.0](https://github.com/protocolbuffers/protobuf/blob/v3.18.0/src/google/protobuf/io/coded_stream.h#L401), [3.11.1](https://github.com/protocolbuffers/protobuf/blob/v3.11.1/src/google/protobuf/io/coded_stream.h#L392).  This PR hacks in a 1-parameter macro for versions < 3.6, which seems to allow compilation for all versions.  

Resolves #49 #43

