### PR TITLE
Fix GAF parsing bug

### DIFF
--- a/include/vg/io/gafkluge.hpp
+++ b/include/vg/io/gafkluge.hpp
@@ -125,7 +125,7 @@ inline void parse_gaf_record(const std::string& gaf_line, GafRecord& gaf_record)
             GafStep step;
             pos = buffer.find_first_of("><", pos);
             next = buffer.find_first_of("><", pos + 1);
-            std::string step_token = buffer.substr(pos, next != std::string::npos ? next - pos + 1 : std::string::npos);
+            std::string step_token = buffer.substr(pos, next != std::string::npos ? next - pos : std::string::npos);
             size_t colon = step_token.find_first_of(':');
             step.is_reverse = step_token[0] == '<';
             if (colon == std::string::npos) {


### PR DESCRIPTION
This is a bad bug that added an extra char to some step names, but vg (where all testing is done) never cared because the names were cast to ints and trailing characters ignored. 