### PR TITLE
Support big writes through stream encapsulation

### DIFF
--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -72,10 +72,10 @@ public:
     static string sniff_tag(::google::protobuf::io::ZeroCopyInputStream& stream);
 
     /// Constructor to wrap a stream.
-    MessageIterator(istream& in);
+    MessageIterator(istream& in, bool verbose = false);
     
     /// Constructor to wrap an existing BGZF 
-    MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf);
+    MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf, bool verbose = false);
     
     /// Represents a pair of a tag value and some message data.
     /// If there is no valid tag for a group, as given in the Registry, the tag will be "".
@@ -170,6 +170,9 @@ private:
     
     /// Since these streams can't be copied or moved, we wrap ours in a uniqueptr_t so we can be moved.
     unique_ptr<BlockedGzipInputStream> bgzip_in;
+    
+    /// Set this to true to print messages about what is being decoded.
+    bool verbose = false;
     
     /// Make sure the given Protobuf-library bool return value is true, and fail otherwise with a message.
     /// Reports the virtual offset of the invalid group and/or message


### PR DESCRIPTION
@xchang1 was reporting some distance index files not being loadable after serialization.

I added some machinery to inspect the offending VPKG-encapsulated files and found that there was nothing wrong with the encapsulation; it was encapsulating a truncated underlying stream at about 2 GB.

I added a test to vg to try and transform a 3 GB block through `with_function_calling_stream`, and found that it did not work.

The underlying problem seems to be in the `fdstream` code we borrowed; the `fdostream`'s `fdoutbuf` doesn't guard against partial writes. The underlying `::write()` on an FD can succeed while only writing part of the data (and it turns out it does do that for us when we try and send more than 2 GB at a time), but the `xsputn()` method on the streambuf is deemed to fave failed if it returns saying it could only write part of the data.

So I added the necessary retry loop to the `xsputn()` method, and now only return that less than the requested number of bytes were written if `::write()` returns an actual error.