### PR TITLE
Support build and large writes on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,9 @@ if (NOT (CMAKE_MAJOR_VERSION EQUAL "3" AND (CMAKE_MINOR_VERSION EQUAL "10" OR CM
 endif()
 
 # Test
-add_executable(test_libvgio test.cpp)
+# TODO: This doesn't link on Mac yet due to missing vtables for STL streams
+# that Protobuf wants.
+add_executable(test_libvgio test.cpp EXCLUDE_FROM_ALL)
 target_link_libraries(test_libvgio vgio_static)
 set_target_properties(test_libvgio PROPERTIES OUTPUT_NAME "test_libvgio")
 set_target_properties(test_libvgio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 # Test
 # TODO: This doesn't link on Mac yet due to missing vtables for STL streams
 # that Protobuf wants.
-add_executable(test_libvgio test.cpp EXCLUDE_FROM_ALL)
+add_executable(test_libvgio EXCLUDE_FROM_ALL test.cpp)
 target_link_libraries(test_libvgio vgio_static)
 set_target_properties(test_libvgio PROPERTIES OUTPUT_NAME "test_libvgio")
 set_target_properties(test_libvgio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")

--- a/include/vg/io/fdstream.hpp
+++ b/include/vg/io/fdstream.hpp
@@ -19,6 +19,7 @@
  *
  * Version: Jul 28, 2002
  * History:
+ *  Nov 10, 2022: add protection against secret MacOS write size limit
  *  Oct 17, 2022: add protection against partial writes
  *  Oct 05, 2020: add stream-wrapping stream and up putback, use unnamespaced void* read/write
  *  Jan 29, 2019: namespace for vg project
@@ -91,7 +92,12 @@ class fdoutbuf : public std::streambuf {
         // than about 2 GB at once.
         std::streamsize total = 0;
         while (total < num) {
-            ssize_t written = ::write(fd,(void*)(s + total),(num - total));
+            // We can't write more than MAX_INT (2^31-1) bytes at once on Mac. See
+            // <https://github.com/erlang/otp/issues/6242#issuecomment-1237641854>.
+            // If we try, we don't get a partial write, we instead get EINVAL.
+            // So make sure never to try on any platform.
+            ssize_t to_write = std::min(num - total, (ssize_t) MAX_INT);
+            ssize_t written = ::write(fd,(void*)(s + total),to_write);
             if (written == -1) {
                 // An error was encountered.
                 return total;

--- a/include/vg/io/fdstream.hpp
+++ b/include/vg/io/fdstream.hpp
@@ -92,11 +92,11 @@ class fdoutbuf : public std::streambuf {
         // than about 2 GB at once.
         std::streamsize total = 0;
         while (total < num) {
-            // We can't write more than MAX_INT (2^31-1) bytes at once on Mac. See
+            // We can't write more than INT_MAX (2^31-1) bytes at once on Mac. See
             // <https://github.com/erlang/otp/issues/6242#issuecomment-1237641854>.
             // If we try, we don't get a partial write, we instead get EINVAL.
             // So make sure never to try on any platform.
-            ssize_t to_write = std::min(num - total, (ssize_t) MAX_INT);
+            ssize_t to_write = std::min(num - total, (ssize_t) INT_MAX);
             ssize_t written = ::write(fd,(void*)(s + total),to_write);
             if (written == -1) {
                 // An error was encountered.


### PR DESCRIPTION
On top of efe7ee968cd956b0cd864bf51671689dc7d0b547 this fixes large writes to the `fdstream`s on Mac, which refuses to write more than 2 GB at a time and errors instead of doing a partial write (see https://github.com/erlang/otp/issues/6242#issuecomment-1237641854).

It also turns off the test binary build by default, since it doesn't seem to want to link properly on Mac, and needs some more engineering.