### PR TITLE
Write fp/fn tags for unmapped reads too in GAF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,9 @@ if (NOT (CMAKE_MAJOR_VERSION EQUAL "3" AND (CMAKE_MINOR_VERSION EQUAL "10" OR CM
 endif()
 
 # Test
-add_executable(test_libvgio test.cpp)
+# TODO: This doesn't link on Mac yet due to missing vtables for STL streams
+# that Protobuf wants.
+add_executable(test_libvgio EXCLUDE_FROM_ALL test.cpp)
 target_link_libraries(test_libvgio vgio_static)
 set_target_properties(test_libvgio PROPERTIES OUTPUT_NAME "test_libvgio")
 set_target_properties(test_libvgio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")

--- a/include/vg/io/fdstream.hpp
+++ b/include/vg/io/fdstream.hpp
@@ -19,6 +19,7 @@
  *
  * Version: Jul 28, 2002
  * History:
+ *  Nov 10, 2022: add protection against secret MacOS write size limit
  *  Oct 17, 2022: add protection against partial writes
  *  Oct 05, 2020: add stream-wrapping stream and up putback, use unnamespaced void* read/write
  *  Jan 29, 2019: namespace for vg project
@@ -91,7 +92,12 @@ class fdoutbuf : public std::streambuf {
         // than about 2 GB at once.
         std::streamsize total = 0;
         while (total < num) {
-            ssize_t written = ::write(fd,(void*)(s + total),(num - total));
+            // We can't write more than INT_MAX (2^31-1) bytes at once on Mac. See
+            // <https://github.com/erlang/otp/issues/6242#issuecomment-1237641854>.
+            // If we try, we don't get a partial write, we instead get EINVAL.
+            // So make sure never to try on any platform.
+            ssize_t to_write = std::min(num - total, (ssize_t) INT_MAX);
+            ssize_t written = ::write(fd,(void*)(s + total),to_write);
             if (written == -1) {
                 // An error was encountered.
                 return total;

--- a/src/alignment_io.cpp
+++ b/src/alignment_io.cpp
@@ -534,16 +534,6 @@ gafkluge::GafRecord alignment_to_gaf(function<size_t(nid_t)> node_to_length,
             gaf.opt_fields["bq"] = make_pair("Z", string_quality_short_to_char(aln.quality()));
         }
 
-        // optional frag_next/prev names
-        if (frag_links == true) {
-            if (aln.has_fragment_next()) {
-                gaf.opt_fields["fn"] = make_pair("Z", aln.fragment_next().name());
-            }
-            if (aln.has_fragment_prev()) {
-                gaf.opt_fields["fp"] = make_pair("Z", aln.fragment_prev().name());
-            }
-        }
-
         if (aln.has_annotation()) {
             auto& annotation = aln.annotation();
             if (annotation.fields().count("proper_pair")) {
@@ -554,6 +544,16 @@ gafkluge::GafRecord alignment_to_gaf(function<size_t(nid_t)> node_to_length,
                 gaf.opt_fields["AD"] = make_pair("i", (annotation.fields().at("support")).string_value());
             }
         }
+    }
+
+    // optional frag_next/prev names
+    if (frag_links == true) {
+      if (aln.has_fragment_next()) {
+        gaf.opt_fields["fn"] = make_pair("Z", aln.fragment_next().name());
+      }
+      if (aln.has_fragment_prev()) {
+        gaf.opt_fields["fp"] = make_pair("Z", aln.fragment_prev().name());
+      }
     }
 
     return gaf;    


### PR DESCRIPTION
Unmapped reads are missing the fragment_prev/fragment_next tags in GAF. It causes errors when surjecting pairs of reads when one or both are unmapped (from GAF).

There is an open issue on vg: https://github.com/vgteam/vg/issues/3711. I also encountered the bug when testing the new HPRC Giraffe-DV WDLs which attempt to use GBZ and GAF as much as possible.

I think it should work now. At least it fixes the problem in the tiny test graph.