### PR TITLE
Fix include references

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ by running the installation script: `./install.sh [INSTALL_LOCATION]`.
 This will install the dynamic library and headers in your home directory unless
 you provide the script with the optional `INSTALL_LOCATION`.
 
+On Mac, you may need to explain how to find OpenMP, and you may not be able to
+use the script. You can install manually instead. For example, if you installed
+OpenMP via Homebrew, it ought to be in `${HOMEBREW_PREFIX}/opt/libomp`, so you
+can run:
+
+```
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${HOME} -DCMAKE_PREFIX_PATH="${HOMEBREW_PREFIX}/opt/libomp" ..
+make
+make install
+```
+
 ## Usage
 
 libvgio exposes two header files `vg/vg.pb.h` and

--- a/include/vg/io/alignment_emitter.hpp
+++ b/include/vg/io/alignment_emitter.hpp
@@ -17,8 +17,8 @@
 #include <htslib/sam.h>
 
 #include <vg/vg.pb.h>
-#include <vg/io/protobuf_emitter.hpp>
-#include <vg/io/stream_multiplexer.hpp>
+#include "protobuf_emitter.hpp"
+#include "stream_multiplexer.hpp"
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/named_node_back_translation.hpp>
 

--- a/include/vg/io/alignment_emitter.hpp
+++ b/include/vg/io/alignment_emitter.hpp
@@ -16,7 +16,7 @@
 #include <htslib/hts.h>
 #include <htslib/sam.h>
 
-#include <vg/vg.pb.h>
+#include "vg/vg.pb.h"
 #include "protobuf_emitter.hpp"
 #include "stream_multiplexer.hpp"
 #include <handlegraph/handle_graph.hpp>

--- a/include/vg/io/alignment_io.hpp
+++ b/include/vg/io/alignment_io.hpp
@@ -5,10 +5,10 @@
 #include <functional>
 #include <zlib.h>
 #include "vg/vg.pb.h"
-#include "htslib/hfile.h"
-#include "htslib/hts.h"
-#include "htslib/sam.h"
-#include "htslib/vcf.h"
+#include <htslib/hfile.h>
+#include <htslib/hts.h>
+#include <htslib/sam.h>
+#include <htslib/vcf.h>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/named_node_back_translation.hpp>
 #include "gafkluge.hpp"

--- a/include/vg/io/alignment_io.hpp
+++ b/include/vg/io/alignment_io.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <functional>
 #include <zlib.h>
-#include <vg/vg.pb.h>
+#include "vg/vg.pb.h"
 #include "htslib/hfile.h"
 #include "htslib/hts.h"
 #include "htslib/sam.h"

--- a/include/vg/io/alignment_io.hpp
+++ b/include/vg/io/alignment_io.hpp
@@ -11,7 +11,7 @@
 #include "htslib/vcf.h"
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/named_node_back_translation.hpp>
-#include "vg/io/gafkluge.hpp"
+#include "gafkluge.hpp"
 
 namespace vg {
 

--- a/include/vg/io/basic_stream.hpp
+++ b/include/vg/io/basic_stream.hpp
@@ -2,7 +2,7 @@
 #define VG_IO_BASIC_STREAM_HPP
 
 #include <string>
-#include <vg/vg.pb.h>
+#include "vg/vg.pb.h"
 
 namespace vg {
 namespace io {

--- a/include/vg/io/edit.hpp
+++ b/include/vg/io/edit.hpp
@@ -1,7 +1,7 @@
 #ifndef VG_IO_EDIT_HPP_INCLUDED
 #define VG_IO_EDIT_HPP_INCLUDED
 
-#include <vg/vg.pb.h>
+#include "vg/vg.pb.h"
 #include <utility>
 
 namespace vg {

--- a/src/alignment_emitter.cpp
+++ b/src/alignment_emitter.cpp
@@ -7,8 +7,8 @@
 #include "vg/io/alignment_emitter.hpp"
 #include "vg/io/alignment_io.hpp"
 #include "vg/io/json2pb.h"
-#include <vg/io/hfile_cppstream.hpp>
-#include <vg/io/stream.hpp>
+#include "vg/io/hfile_cppstream.hpp"
+#include "vg/io/stream.hpp"
 #include <omp.h>
 
 #include <sstream>

--- a/src/json2pb.cpp
+++ b/src/json2pb.cpp
@@ -21,7 +21,7 @@
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/struct.pb.h>
 
-#include <vg/io/json2pb.h>
+#include "vg/io/json2pb.h"
 
 #include <stdexcept>
 #include <cstdio>

--- a/test.cpp
+++ b/test.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <string>
 
-#include <vg/vg.pb.h>
+#include "vg/vg.pb.h"
 #include <google/protobuf/descriptor.h>
 
 int main (int arcg, char** argv) {


### PR DESCRIPTION
We really should use "" for internal-to-package references and <> for references to things like htslib.

I'm not *quite* changing over to relative paths for this, but maybe I should?

Also I'm updating libhandlegraph to avoid some warnings, and documenting the build on Mac so you can actually find OpenMP.