### PR TITLE
Use 8 decoding threads when reading BGZF files (GAM, etc.)

### DIFF
--- a/include/vg/io/blocked_gzip_input_stream.hpp
+++ b/include/vg/io/blocked_gzip_input_stream.hpp
@@ -80,6 +80,10 @@ public:
     /// Return true if the stream being read really is BGZF, and false if we
     /// are operating on a non-blocked GZIP or uncompressed file.
     virtual bool IsBGZF() const;
+
+    /// Turn on multithreaded decompression. Return true if successful and
+    /// false if the BGZF could not set up its thread pool.
+    virtual bool EnableMultiThreading(size_t thread_count);
     
     /// Return true if the given istream looks like GZIP-compressed data (i.e.
     /// has the GZIP magic number as its first two bytes). Replicates some of

--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -72,7 +72,7 @@ public:
     static string sniff_tag(::google::protobuf::io::ZeroCopyInputStream& stream);
 
     /// Constructor to wrap a stream.
-    MessageIterator(istream& in, bool verbose = false);
+    MessageIterator(istream& in, bool verbose = false, size_t thread_count = 0);
     
     /// Constructor to wrap an existing BGZF 
     MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf, bool verbose = false);

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -157,8 +157,10 @@ void for_each_parallel_impl(std::istream& in,
             if (!retval) throw std::runtime_error("obsolete, invalid, or corrupt protobuf input");
         };
         
-        // We do our own multi-threaded Protobuf decoding, but we batch up our strings by pulling them from this iterator.
-        MessageIterator message_it(in);
+        // We do our own multi-threaded Protobuf decoding, but we batch up our
+        // strings by pulling them from this iterator, which we also
+        // multi-thread for decompression.
+        MessageIterator message_it(in, false, 8);
 
         std::vector<std::string> *batch = nullptr;
         

--- a/src/blocked_gzip_input_stream.cpp
+++ b/src/blocked_gzip_input_stream.cpp
@@ -261,6 +261,10 @@ bool BlockedGzipInputStream::IsBGZF() const {
     return handle->is_compressed && !handle->is_gzip;
 }
 
+bool BlockedGzipInputStream::EnableMultiThreading(size_t thread_count) {
+    return bgzf_mt(handle, thread_count, 256) == 0;
+}
+
 bool BlockedGzipInputStream::SmellsLikeGzip(std::istream& in) {
     // TODO: We also assume that we can sniff the magic number bytes
     // from the input stream and then put them both back. The C spec

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -140,8 +140,13 @@ string MessageIterator::sniff_tag(::google::protobuf::io::ZeroCopyInputStream& s
     return tag;
 }
 
-MessageIterator::MessageIterator(istream& in, bool verbose) : MessageIterator(unique_ptr<BlockedGzipInputStream>(new BlockedGzipInputStream(in)), verbose) {
-    // Nothing to do!
+MessageIterator::MessageIterator(istream& in, bool verbose, size_t thread_count) : MessageIterator(unique_ptr<BlockedGzipInputStream>(new BlockedGzipInputStream(in)), verbose) {
+    if (thread_count > 1) {
+        // After making the BGZF, turn on multithreaded decoding
+        if (!bgzip_in->EnableMultiThreading(thread_count)) {
+            throw std::runtime_error("Cound not enable multithreaded BGZF decoding");
+        }
+    }
 }
 
 MessageIterator::MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf, bool verbose) :


### PR DESCRIPTION
I noticed that our new cluster can deliver GAM files at about 1.5 GB/s, but gzip decompression runs at something like 40 MB/s.

This tells htslib to use 8 decompression threads whenever we want to do a parallel read through stream.hpp. This ought to make things like `vg filter` better able to keep actual work threads busy when reads are long and take a lot of decompressing.

I'm not doing any clever stuff to budget the threads out of the user-requested thread count, so the user is always going to get 8 decoding threads even if they ask for e.g. 1 or 2 threads for the vg run. It's possible this will cause trouble in cases like containers where CPU is actually constrained, but I don't think htslib will let the decompression get too far ahead of the processing.