### PR TITLE
Add support for progress reporting to the stream.hpp API

### DIFF
--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -128,9 +128,9 @@ void for_each(std::istream& in,
 // Parallelized versions of for_each
 
 // Default progress function that does nothing.
-std::function<void(size_t, size_t)> NO_PROGRESS;
+const std::function<void(size_t, size_t)> NO_PROGRESS = [](size_t, size_t) {};
 // Default waiting function that always returns true.
-std::function<bool(void)> NO_WAIT;
+const std::function<bool(void)> NO_WAIT = []() { return true; };
 
 // First, an internal implementation underlying several variants below.
 // lambda2 is invoked on interleaved pairs of elements from the stream. The

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -170,7 +170,7 @@ void for_each_parallel_impl(std::istream& in,
 
     // this loop handles a chunked file with many pieces
     // such as we might write in a multithreaded process
-    #pragma omp parallel default(none) shared(in, lambda1, lambda2, batches_outstanding, max_batches_outstanding, single_threaded_until_true, cerr, batch_size)
+    #pragma omp parallel default(none) shared(in, lambda1, lambda2, progress, stream_length, batches_outstanding, max_batches_outstanding, single_threaded_until_true, cerr, batch_size)
     #pragma omp single
     {
         auto handle = [](bool retval) -> void {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -15,6 +15,9 @@ void finish(std::ostream& out, bool compressed) {
     }
 }
 
+std::function<void(size_t, size_t)> NO_PROGRESS = [](size_t, size_t) {};
+std::function<bool(void)> NO_WAIT = []() { return true; };
+
 }
 
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -15,9 +15,6 @@ void finish(std::ostream& out, bool compressed) {
     }
 }
 
-std::function<void(size_t, size_t)> NO_PROGRESS = [](size_t, size_t) {};
-std::function<bool(void)> NO_WAIT = []() { return true; };
-
 }
 
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -15,6 +15,35 @@ void finish(std::ostream& out, bool compressed) {
     }
 }
 
+size_t get_stream_length(std::istream& in) {
+    in.clear();
+    // Get where we are right now
+    auto start_pos = in.tellg();
+    if (start_pos < 0 || !in.good()) {
+        // We can't get a position to seek back to
+        return std::numeric_limits<size_t>::max();
+    }
+    // Go to the end
+    in.seekg(0, std::ios_base::end);
+    auto end_pos = in.tellg();
+    // Go back
+    in.seekg(start_pos);
+    in.clear();
+    if (end_pos < 0) {
+        // End position wasn't tellable.
+        return std::numeric_limits<size_t>::max();
+    }
+    return end_pos;
+}
+
+size_t get_stream_position(std::istream& in) {
+    auto cur_pos = in.tellg();
+    if (cur_pos < 0) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return cur_pos;
+}
+
 }
 
 }


### PR DESCRIPTION
This lets you pass a progress callback to `for_each()` and `for_each_parallel()`.