### PR TITLE
Fix multithreading and progress reporting together

### DIFF
--- a/include/vg/io/blocked_gzip_input_stream.hpp
+++ b/include/vg/io/blocked_gzip_input_stream.hpp
@@ -24,7 +24,11 @@ public:
     /// Make a new stream reading from the given C++ std::istream, wrapping it
     /// in a BGZF. The stream must be at a BGZF block header, since the header
     /// info is peeked.
-    BlockedGzipInputStream(std::istream& stream);
+    ///
+    /// If thread_count is more than 1, enables multi-threaded BGZF decoding.
+    /// This needs to be part of the comstructor to ensure that it happens
+    /// before any data is read through the decoder.
+    BlockedGzipInputStream(std::istream& stream, size_t thread_count = 0);
 
     /// Destroy the stream.
     virtual ~BlockedGzipInputStream();
@@ -81,10 +85,6 @@ public:
     /// are operating on a non-blocked GZIP or uncompressed file.
     virtual bool IsBGZF() const;
 
-    /// Turn on multithreaded decompression. Return true if successful and
-    /// false if the BGZF could not set up its thread pool.
-    virtual bool EnableMultiThreading(size_t thread_count);
-    
     /// Return true if the given istream looks like GZIP-compressed data (i.e.
     /// has the GZIP magic number as its first two bytes). Replicates some of
     /// the sniffing logic that htslib does, but puts back the sniffed

--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -72,6 +72,9 @@ public:
     static string sniff_tag(::google::protobuf::io::ZeroCopyInputStream& stream);
 
     /// Constructor to wrap a stream.
+    /// If thread_count is more than 1, enables multi-threaded BGZF decoding,
+    /// in which case no method on the stream may be called by anyone else
+    /// until the MessageIterator is destroyed!
     MessageIterator(istream& in, bool verbose = false, size_t thread_count = 0);
     
     /// Constructor to wrap an existing BGZF 

--- a/include/vg/io/protobuf_iterator.hpp
+++ b/include/vg/io/protobuf_iterator.hpp
@@ -36,7 +36,9 @@ using namespace std;
 template <typename T>
 class ProtobufIterator {
 public:
-    /// Constructor
+    /// Constructor. Uses single-threaded decoding, so methods may be called on
+    /// the given stream from other code while the ProtobufIterator exists, as
+    /// long as no ProtobufIterator method is running.
     ProtobufIterator(istream& in);
     
     ///////////
@@ -117,6 +119,7 @@ public:
 private:
     
     /// Wrap a MessageIterator and just do Protobuf parsing on top of that.
+    /// We always use one that is single-threaded.
     MessageIterator message_it;
     
     /// We always maintain a parsed version of the current message.

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -191,8 +191,9 @@ void for_each_parallel_impl(std::istream& in,
         };
         
         // We do our own multi-threaded Protobuf decoding, but we batch up our
-        // strings by pulling them from this iterator.
-        MessageIterator message_it(in, false);
+        // strings by pulling them from this iterator, which we also
+        // multi-thread for decompression.
+        MessageIterator message_it(in, false, 8);
 
         std::vector<std::string> *batch = nullptr;
         

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -191,9 +191,8 @@ void for_each_parallel_impl(std::istream& in,
         };
         
         // We do our own multi-threaded Protobuf decoding, but we batch up our
-        // strings by pulling them from this iterator, which we also
-        // multi-thread for decompression.
-        MessageIterator message_it(in, false, 8);
+        // strings by pulling them from this iterator.
+        MessageIterator message_it(in, false);
 
         std::vector<std::string> *batch = nullptr;
         

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -140,13 +140,8 @@ string MessageIterator::sniff_tag(::google::protobuf::io::ZeroCopyInputStream& s
     return tag;
 }
 
-MessageIterator::MessageIterator(istream& in, bool verbose, size_t thread_count) : MessageIterator(unique_ptr<BlockedGzipInputStream>(new BlockedGzipInputStream(in)), verbose) {
-    if (thread_count > 1) {
-        // After making the BGZF, turn on multithreaded decoding
-        if (!bgzip_in->EnableMultiThreading(thread_count)) {
-            throw std::runtime_error("Cound not enable multithreaded BGZF decoding");
-        }
-    }
+MessageIterator::MessageIterator(istream& in, bool verbose, size_t thread_count) : MessageIterator(unique_ptr<BlockedGzipInputStream>(new BlockedGzipInputStream(in, thread_count)), verbose) {
+    // Nothing to do!
 }
 
 MessageIterator::MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf, bool verbose) :


### PR DESCRIPTION
This revises the multithreaded BGZF decode so that you always set it up in the reader's constructor. It also fixes the progress reporting to not clash with the BGZF decoder's internal threads that are trying to read from the C++ stream, since it's not safe to tell the stream while that is happening.