### PR TITLE
Detect file truncation on write and on read

### DIFF
--- a/include/vg/io/blocked_gzip_input_stream.hpp
+++ b/include/vg/io/blocked_gzip_input_stream.hpp
@@ -9,6 +9,10 @@ namespace vg {
 
 namespace io {
 
+/// Represents an error where an input blocked GZIP file has been truncated.
+class TruncatedBGZFError: public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
 
 /// Protobuf-style ZeroCopyInputStream that reads data from blocked gzip
 /// format, and allows interacting with virtual offsets.
@@ -28,6 +32,9 @@ public:
     /// If thread_count is more than 1, enables multi-threaded BGZF decoding.
     /// This needs to be part of the comstructor to ensure that it happens
     /// before any data is read through the decoder.
+    ///
+    /// Throws TruncatedBGZFError immediately if the file is seekable and lacks
+    /// the BGZF EOF block.
     BlockedGzipInputStream(std::istream& stream, size_t thread_count = 0);
 
     /// Destroy the stream.
@@ -84,6 +91,10 @@ public:
     /// Return true if the stream being read really is BGZF, and false if we
     /// are operating on a non-blocked GZIP or uncompressed file.
     virtual bool IsBGZF() const;
+
+    /// Returns true if the stream being read is BGZF, it is seekable, and the
+    /// EOF marker at the end is missing.
+    virtual bool MissingEOF();
 
     /// Return true if the given istream looks like GZIP-compressed data (i.e.
     /// has the GZIP magic number as its first two bytes). Replicates some of

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -26,7 +26,7 @@ using namespace std;
 
 /// Get the length of the input stream, or std::numeric_limits<size_t>::max() if unavailable.
 size_t get_stream_length(std::istream& in);
-/// Get the current offset in the input stream, or std;:numeric_limits<size_t>::max() if unavailable.
+/// Get the current offset in the input stream, or std::numeric_limits<size_t>::max() if unavailable.
 size_t get_stream_position(std::istream& in);
 
 /// Write the EOF marker to the given stream, so that readers won't complain that it might be truncated when they read it in.

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -183,25 +183,28 @@ void for_each_parallel_impl(std::istream& in,
     cerr << "Looping over file in batches of size " << batch_size << endl;
 #endif
 
+    // Construct the MessageIterator in the main thread so exceptions in its
+    // startup can be caught.
+
+    // We do our own multi-threaded Protobuf decoding, but we batch up our
+    // strings by pulling them from this iterator, which we also
+    // multi-thread for decompression.
+    //
+    // Note that as long as this exists, we **may not** use the "in"
+    // stream! Even just to tell() it for the current position! This will
+    // start backgorund threads that use the stream, and on mac at least
+    // even a tellg() can mutate the stream internally and cause the
+    // background threads to segfault.
+    MessageIterator message_it(in, false, 8);
+
     // this loop handles a chunked file with many pieces
     // such as we might write in a multithreaded process
-    #pragma omp parallel default(none) shared(in, lambda1, lambda2, progress, stream_length, batches_outstanding, max_batches_outstanding, single_threaded_until_true, cerr, batch_size)
+    #pragma omp parallel default(none) shared(message_it, lambda1, lambda2, progress, stream_length, batches_outstanding, max_batches_outstanding, single_threaded_until_true, cerr, batch_size)
     #pragma omp single
     {
         auto handle = [](bool retval) -> void {
             if (!retval) throw std::runtime_error("obsolete, invalid, or corrupt protobuf input");
         };
-        
-        // We do our own multi-threaded Protobuf decoding, but we batch up our
-        // strings by pulling them from this iterator, which we also
-        // multi-thread for decompression.
-        //
-        // Note that as long as this exists, we **may not** use the "in"
-        // stream! Even just to tell() it for the current position! This will
-        // start backgorund threads that use the stream, and on mac at least
-        // even a tellg() can mutate the stream internally and cause the
-        // background threads to segfault.
-        MessageIterator message_it(in, false, 8);
 
         std::vector<std::string> *batch = nullptr;
         

--- a/include/vg/io/stream_multiplexer.hpp
+++ b/include/vg/io/stream_multiplexer.hpp
@@ -92,7 +92,7 @@ public:
      * written by the given thread so far. Implicitly also creates a
      * breakpoint.
      */
-     void register_barrier(size_t thread_number);
+    void register_barrier(size_t thread_number);
      
     /**
      * Cancel the writing of and discard all data written since the previous
@@ -105,7 +105,7 @@ public:
      * breakpoint for the given thread. If count is more than the number of
      * bytes since the last breakpoint, rewinds only to the last breakpoint.
      */
-     void discard_bytes(size_t thread_number, size_t count);
+    void discard_bytes(size_t thread_number, size_t count);
     
 private:
 

--- a/src/blocked_gzip_input_stream.cpp
+++ b/src/blocked_gzip_input_stream.cpp
@@ -276,7 +276,7 @@ bool BlockedGzipInputStream::MissingEOF() {
         if (check_result == -1) {
             // Something went badly wrong and errno is set.
             int captured_errno = errno;
-            throw std::runtime_error("Could not check for EOF block on input: " + strerror(captured_errno));
+            throw std::runtime_error("Could not check for EOF block on input: " + std::string(strerror(captured_errno)));
         } else if (check_result == 0) {
             // We know the EOF marker is missing
             return true;


### PR DESCRIPTION
This adds error detection for failed writes in the stream multiplexer, and will fail if you try and open a BGZF file that is seekable and truncated.

This should give better results when it is possible you will run out of disk space when working with GAM files.