### PR TITLE
Port to Protobuf 32

### DIFF
--- a/include/vg/io/message_iterator.hpp
+++ b/include/vg/io/message_iterator.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/stubs/common.h>
 
 #include "blocked_gzip_input_stream.hpp"
 
@@ -22,6 +23,9 @@
 // protobuf scrapped the two-parameter version of this in 3.6.0
 // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/src/google/protobuf/io/coded_stream.h#L387-L391
 // so we hack in support ourselves
+#ifndef GOOGLE_PROTOBUF_VERSION
+#error "Cannot determine version of Protobuf library from GOOGLE_PROTOBUF_VERSION macro"
+#endif
 #if (GOOGLE_PROTOBUF_VERSION < 3006000)
 #define SetTotalBytesLimit(N) SetTotalBytesLimit(N, N)
 #endif

--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -224,7 +224,7 @@ public:
      * given type.
      */
     template<typename Message>
-    static const string& get_protobuf_tag();
+    static string get_protobuf_tag();
 
     /**
      * Check to see if the given tag is expected when deserializing Protobuf
@@ -573,7 +573,7 @@ const pair<string, save_function_t>* Registry::find_saver() {
 }
 
 template<typename Message>
-const string& Registry::get_protobuf_tag() {
+string Registry::get_protobuf_tag() {
     // Get our state
     Tables& tables = get_tables();
 
@@ -591,12 +591,12 @@ const string& Registry::get_protobuf_tag() {
 #ifdef debug
         cerr << "Tag not found for " << Message::descriptor()->full_name() << endl;
 #endif
-        const string& tag = Message::descriptor()->full_name();
+        auto tag = Message::descriptor()->full_name();
         
         // Limit tag length
         assert(tag.size() <= MAX_TAG_LENGTH);
         
-        return tag;
+        return std::string(tag);
     }
 }
 

--- a/include/vg/io/stream.hpp
+++ b/include/vg/io/stream.hpp
@@ -221,7 +221,7 @@ void for_each_parallel_impl(std::istream& in,
                 // This isn't the data we were expecting.
                 if (first_message) {
                     // If this happens on the very first message, we know this is the wrong kind of stream.
-                    throw std::runtime_error("expected a stream of " + T::descriptor()->full_name() + " but found first message with tag " + tag_and_data.first);
+                    throw std::runtime_error("expected a stream of " + std::string(T::descriptor()->full_name()) + " but found first message with tag " + tag_and_data.first);
                 } else {
                     // On other mesages, just skip them if they aren't what we care about.
                     first_message = false;

--- a/src/json2pb.cpp
+++ b/src/json2pb.cpp
@@ -49,7 +49,7 @@ class j2pb_error : public std::exception {
 	std::string _error;
 public:
 	j2pb_error(const std::string &e) : _error(e) {}
-	j2pb_error(const FieldDescriptor *field, const std::string &e) : _error(field->name() + ": " + e) {}
+	j2pb_error(const FieldDescriptor *field, const std::string &e) : _error(std::string(field->name()) + ": " + e) {}
 	virtual ~j2pb_error() throw() {};
 
 	virtual const char *what() const throw () { return _error.c_str(); };
@@ -160,7 +160,7 @@ static json_t * _pb2json(const Message& msg)
 		else
 			continue;
 
-		const std::string &name = (field->is_extension())?field->full_name():field->name();
+        std::string name((field->is_extension())?field->full_name():field->name());
 		json_object_set_new(root, name.c_str(), jf);
 	}
 	return _auto.release();
@@ -174,7 +174,7 @@ static json_t * _struct2json(const google::protobuf::Struct& msg) {
     auto status = google::protobuf::util::MessageToJsonString(msg, &buffer, opts);
     
     if (!status.ok()) {
-        throw std::runtime_error("Could not serialize " + msg.GetTypeName() + ": " + status.ToString());
+        throw std::runtime_error("Could not serialize " + std::string(msg.GetTypeName()) + ": " + status.ToString());
     }
     
     // Now parse back
@@ -329,7 +329,7 @@ static void _json2struct(google::protobuf::Struct& msg, json_t *root)
     // Parse it as a struct
     auto status = google::protobuf::util::JsonStringToMessage(buf, &msg);
     if (!status.ok()) {
-        throw std::runtime_error("Could not deserialize " + msg.GetTypeName() + ": " + status.ToString());
+        throw std::runtime_error("Could not deserialize " + std::string(msg.GetTypeName()) + ": " + status.ToString());
     }
 }
 


### PR DESCRIPTION
vg started failing Mac CI tests because the current Homebrew release of Protobuf had some breaking changes related to Protobuf API return types. See:
* https://github.com/vgteam/vg/actions/runs/16995911969/job/48186437774
* https://protobuf.dev/support/migration/#v30

This fixes libvgio so it can work with newer Protobuf versions. This mostly consists of copying things into `std::string`s, because we can't really do things like "replace STL containers with Abseil ones" and because we also need to keep working on older Protobuf versions that don't hand us views.