### PR TITLE
Add base qualities for unaligned sequences in GAF output

### DIFF
--- a/src/alignment_io.cpp
+++ b/src/alignment_io.cpp
@@ -913,6 +913,12 @@ gafkluge::GafRecord alignment_to_gaf(function<size_t(nid_t)> node_to_length,
             string cs_cigar_str = "+" + aln.sequence();
             gaf.opt_fields["cs"] = make_pair("Z", std::move(cs_cigar_str));
         }
+
+        // emit base qualities for unaligned sequences
+        // optional base qualities                                                                                                                      
+        if (base_quals && !aln.quality().empty()) {                                                                                                     
+            gaf.opt_fields["bq"] = make_pair("Z", string_quality_short_to_char(aln.quality()));                                                         
+        }
     }
 
     // optional frag_next/prev names


### PR DESCRIPTION
**Description**
This PR ensures that base quality strings (QUAL) are preserved and included when writing unaligned sequences to GAF (Graph Alignment Format) file.

**Motivation**
Preserving sequence data integrity. Quality scores are critical for downstream variant calling, error correction, and filtering. Dropping these scores for unaligned reads makes it impossible to re-evaluate those sequences later without referring back to the original raw files.