### PR TITLE
Support registering more loaders without savers

### DIFF
--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -157,6 +157,14 @@ public:
     template<typename Handled, typename... Bases>
     static void register_bare_loader_saver_with_magic(const string& tag, const string& magic,
         bare_load_function_t loader, bare_save_function_t saver);
+
+    /**
+     * Like register_bare_loader_saver_with_magic(), except that no saving
+     * function is registered.
+     */
+    template<typename Handled, typename... Bases>
+    static void register_bare_loader_with_magic(const string& tag, const string& magic,
+        bare_load_function_t loader);
         
     /**
      * Like register_bare_loader_saver_with_magic(), except that multiple magic
@@ -165,6 +173,14 @@ public:
     template<typename Handled, typename... Bases>
     static void register_bare_loader_saver_with_magics(const string& tag, const vector<string>& magics,
         bare_load_function_t loader, bare_save_function_t saver);
+
+    /**
+     * Like register_bare_loader_saver_with_magics(), except that no saving
+     * function is registered.
+     */
+    template<typename Handled, typename... Bases>
+    static void register_bare_loader_with_magics(const string& tag, const vector<string>& magics,
+        bare_load_function_t loader);
 
     /**
      * Generealization of register_bare_loader_saver_with_magic, where user can supply their
@@ -465,11 +481,35 @@ void Registry::register_bare_loader_saver_with_magic(const string& tag, const st
 }
 
 template<typename Handled, typename... Bases>
+void Registry::register_bare_loader_saver_with_magic(const string& tag, const string& magic,
+    bare_load_function_t loader) {
+
+    // Register with just one magic
+    register_bare_loader_with_magics<Handled, Bases...>(tag, vector<string>({magic}), loader);
+
+}
+
+template<typename Handled, typename... Bases>
 void Registry::register_bare_loader_saver_with_magics(const string& tag, const vector<string>& magics,
     bare_load_function_t loader, bare_save_function_t saver) {
 
     // Register the type-tagged wrapped functions
     register_loader_saver<Handled, Bases...>(tag, wrap_bare_loader(loader), wrap_bare_saver(saver));
+    
+    for (auto& magic : magics) {
+        // Register the bare stream loader for each magic
+        register_bare_loader<Handled, Bases...>(loader, [magic](istream& in_stream) {
+                return sniff_magic(in_stream, magic);  
+            });
+    }
+}
+
+template<typename Handled, typename... Bases>
+void Registry::register_bare_loader_with_magics(const string& tag, const vector<string>& magics,
+    bare_load_function_t loader) {
+
+    // Register the type-tagged wrapped function
+    register_loader<Handled, Bases...>(tag, wrap_bare_loader(loader));
     
     for (auto& magic : magics) {
         // Register the bare stream loader for each magic

--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -197,6 +197,13 @@ public:
     template<typename Handled, typename... Bases>
     static void register_bare_loader_saver_with_magic_and_filename(const string& tag, const string& magic,
         bare_load_function_with_filename_t loader, bare_save_function_t saver);
+
+    /**
+     * Like register_bare_loader_saver_with_magic_and_filename but does not register a saver.
+     */
+    template<typename Handled, typename... Bases>
+    static void register_bare_loader_with_magic_and_filename(const string& tag, const string& magic,
+        bare_load_function_with_filename_t loader);
         
     /**
      * Register a load function for a tag. The empty tag means it can run on
@@ -546,6 +553,17 @@ void Registry::register_bare_loader_saver_with_magic_and_filename(const string& 
     });
     register_saver<Handled, Bases...>(tag, wrap_bare_saver(saver));
 
+}
+
+template<typename Handled, typename... Bases>
+void Registry::register_bare_loader_with_magic_and_filename(const string& tag, const string& magic,
+    bare_load_function_with_filename_t loader) {
+
+    assert(tag.size() <= MAX_TAG_LENGTH);
+
+    register_bare_loader_with_filename<Handled, Bases...>(loader, [magic](istream& in_stream) {
+        return sniff_magic(in_stream, magic);
+    });
 }
         
 

--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -488,7 +488,7 @@ void Registry::register_bare_loader_saver_with_magic(const string& tag, const st
 }
 
 template<typename Handled, typename... Bases>
-void Registry::register_bare_loader_saver_with_magic(const string& tag, const string& magic,
+void Registry::register_bare_loader_with_magic(const string& tag, const string& magic,
     bare_load_function_t loader) {
 
     // Register with just one magic


### PR DESCRIPTION
This should make it possible to add loaders for magic-number files that we don't also know how to save.